### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,5 +1,9 @@
 name: build
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/idealo/cctray-hub/security/code-scanning/1](https://github.com/idealo/cctray-hub/security/code-scanning/1)

To fix the problem, specify a `permissions` block at either the workflow root or within the `build` job, assigning only the minimal privileges required. Since this workflow checks out code, builds it, and pushes a Docker image to GitHub Container Registry (GHCR), it needs `contents: read` for code checkout and `packages: write` to push to GHCR. The best solution is to add the `permissions` key at the appropriate level—at the root of the workflow (.github/workflows/gradle.yml), so the permissions apply to all jobs (there is only one job: `build`). Insert the following block after the `name:` declaration and before `on:`:

```yaml
permissions:
  contents: read
  packages: write
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
